### PR TITLE
use 'sed' in prepare_64bit_asio

### DIFF
--- a/prepare_64bit_asio
+++ b/prepare_64bit_asio
@@ -1,9 +1,9 @@
 #!/bin/sh
-ed -s asio.h <<< $'g/unsigned long/s//ULONG/g\nw\nq'
-ed -s asio.h <<< $'g/long long int/s//LONGLONG/g\nw\nq'
-ed -s asio.h <<< $'g/long int/s//LONG/g\nw\nq'
-ed -s asio.h <<< $'g/long/s//LONG/g\nw\nq'
-ed -s asio.h <<< $'g/(\*bufferSwitch)/s//(CALLBACK *bufferSwitch)/g\nw\nq'
-ed -s asio.h <<< $'g/(\*sampleRateDidChange)/s//(CALLBACK *sampleRateDidChange)/g\nw\nq'
-ed -s asio.h <<< $'g/(\*asioMessage)/s//(CALLBACK *asioMessage)/g\nw\nq'
-ed -s asio.h <<< $'g/(\*bufferSwitchTimeInfo)/s//(CALLBACK *bufferSwitchTimeInfo)/g\nw\nq'
+sed -i -e 's/unsigned long/ULONG/g' asio.h
+sed -i -e 's/long long int/LONGLONG/g' asio.h
+sed -i -e 's/long int/LONG/g' asio.h
+sed -i -e 's/long/LONG/g' asio.h
+sed -i -e 's/(\*bufferSwitch)/(CALLBACK *bufferSwitch)/g' asio.h
+sed -i -e 's/(\*sampleRateDidChange)/(CALLBACK *sampleRateDidChange)/g' asio.h
+sed -i -e 's/(\*asioMessage)/(CALLBACK *asioMessage)/g' asio.h
+sed -i -e 's/(\*bufferSwitchTimeInfo)/(CALLBACK *bufferSwitchTimeInfo)/g' asio.h


### PR DESCRIPTION
ed is not installed by default on some systems, but sed likely is.

This patch also fixes the script not running correctly on /bin/dash, which
/bin/sh points to on Debian/Ubuntu systems.

