### PR TITLE
Update prepare_64bit_asio

### DIFF
--- a/prepare_64bit_asio
+++ b/prepare_64bit_asio
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 ed -s asio.h <<< $'g/unsigned long/s//ULONG/g\nw\nq'
 ed -s asio.h <<< $'g/long long int/s//LONGLONG/g\nw\nq'
 ed -s asio.h <<< $'g/long int/s//LONG/g\nw\nq'


### PR DESCRIPTION
Use bash in prepare_64_bit asio as debian doesn't provide >>> with the default shell.

This is the fixed proposed in.
https://github.com/jhernberg/wineasio/issues/3